### PR TITLE
updateto use u9 vnext

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,7 @@
+# Release 0.1.2
+
+- Support for ArcGIS Runtime SDK for Android 100.9.0
+
 # Release 0.1.1
 
 - Adds doc table of contents to root README.md and docs/index.md

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
         versionCode 1
-        versionName "0.1.1"
+        versionName "0.1.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -41,7 +41,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.esri.arcgisruntime:arcgis-android:100.8.0'
+    implementation 'com.esri.arcgisruntime:arcgis-android:100.9.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.2.1'
     implementation 'androidx.navigation:navigation-ui-ktx:2.2.1'

--- a/app/src/main/res/layout/fragment_navigation_drawer.xml
+++ b/app/src/main/res/layout/fragment_navigation_drawer.xml
@@ -20,6 +20,7 @@
     <data>
         <import type="android.view.View"/>
         <import type="com.esri.arcgisruntime.ArcGISRuntimeEnvironment"/>
+        <import type="com.esri.arcgisruntime.opensourceapps.datacollection.BuildConfig"/>
         <variable
                 name="dataCollectionViewModel"
                 type="com.esri.arcgisruntime.opensourceapps.datacollection.viewmodels.DataCollectionViewModel" />
@@ -157,7 +158,7 @@
                 android:id="@+id/appNameVersion"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{@string/app_name_with_version(@string/app_version)}"
+                android:text="@{@string/app_name_with_version(BuildConfig.VERSION_NAME)}"
                 android:textColor="#B8DAB8"
                 android:textSize="12sp"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,6 @@
 <resources>
     <string name="app_name">Data Collection</string>
     <string name="app_name_with_version">Data Collection %s</string>
-    <string name="app_version">0.1.1</string>
-
     <string name="arcgis_runtime_sdk">ArcGIS Runtime SDK %s</string>
 
     <string name="log_in">Log in</string>


### PR DESCRIPTION
https://github.com/ArcGIS/open-source-apps/issues/423
Changes for merging into v.next branch- 
- adds Support for ArcGIS Runtime SDK for Android 100.9.0

- removes string value for app version name from strings.xml and now uses BuildConfig.VersionName