### PR TITLE
Main- Update to use ArcGIS runtime update 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ If there are changes made in the original repository, you can sync the fork to k
 ## Resources
 
 * [ArcGIS Runtime SDK for Android Developers Site](https://developers.arcgis.com/android/)
-* [ArcGIS Apps Blog](https://www.esri.com/arcgis-blog/apps/)
 * [ArcGIS Developer Blog](https://www.esri.com/arcgis-blog/developers/)
 * [twitter@ArcGISRuntime](https://twitter.com/ArcGISRuntime)
 * [twitter@esri](http://twitter.com/esri)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Read the [docs](./docs/README.md) for a detailed explanation of the application,
 
 ## Development Instructions
 
-Data Collection is an [Android Studio](http://developer.android.com/sdk/index.html) project and app module that can be directly cloned and imported into Android Studio.
+Data Collection is an [Android Studio](https://developer.android.com/studio) project and app module that can be directly cloned and imported into Android Studio.
 
 1. Log in to [ArcGIS for Developers](https://developers.arcgis.com/) and [register](https://developers.arcgis.com/applications/#/) your app.
 
@@ -109,13 +109,13 @@ If there are changes made in the original repository, you can sync the fork to k
 
 ## Requirements
 
-* [Android Studio](http://developer.android.com/sdk/index.html)
+* [Android Studio](https://developer.android.com/studio)
 
 ## Resources
 
 * [ArcGIS Runtime SDK for Android Developers Site](https://developers.arcgis.com/android/)
-* [ArcGIS Mobile Blog](http://blogs.esri.com/esri/arcgis/category/mobile/)
-* [ArcGIS Developer Blog](http://blogs.esri.com/esri/arcgis/category/developer/)
+* [ArcGIS Apps Blog](https://www.esri.com/arcgis-blog/apps/)
+* [ArcGIS Developer Blog](https://www.esri.com/arcgis-blog/developers/)
 * [twitter@ArcGISRuntime](https://twitter.com/ArcGISRuntime)
 * [twitter@esri](http://twitter.com/esri)
 
@@ -147,4 +147,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
 
-For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/latest/guide/license-your-app.htm).
+For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/license-and-deployment/).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Read the [docs](./docs/README.md) for a detailed explanation of the application,
 
 ## Development Instructions
 
-Data Collection is an [Android Studio](https://developer.android.com/studio) project and app module that can be directly cloned and imported into Android Studio.
+Data Collection is an [Android Studio](https://developer.android.com/studio/) project and app module that can be directly cloned and imported into Android Studio.
 
 1. Log in to [ArcGIS for Developers](https://developers.arcgis.com/) and [register](https://developers.arcgis.com/applications/#/) your app.
 
@@ -109,7 +109,7 @@ If there are changes made in the original repository, you can sync the fork to k
 
 ## Requirements
 
-* [Android Studio](https://developer.android.com/studio)
+* [Android Studio](https://developer.android.com/studio/)
 
 ## Resources
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,7 @@
+# Release 0.1.4
+
+- Support for ArcGIS Runtime SDK for Android 100.10.0
+
 # Release 0.1.3
 
 - Updates project to favor the use of secured `https` rather than `http`

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
         versionCode 1
-        versionName "0.1.3"
+        versionName "0.1.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -38,20 +38,20 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.esri.arcgisruntime:arcgis-android:100.9.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'com.esri.arcgisruntime:arcgis-android:100.10.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.2.1'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.2.1'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.3.3'
     implementation "androidx.cardview:cardview:1.0.0"
-    implementation 'com.google.android.material:material:1.2.0-alpha04'
+    implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0'
-    implementation 'androidx.security:security-crypto:1.0.0-rc01'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0'
+    implementation 'androidx.security:security-crypto:1.1.0-alpha03'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.4.21'
     repositories {
         google()
         jcenter()
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 16 11:06:45 PST 2020
+#Fri Feb 19 11:02:24 PST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
- Update versions - 
   Android Gradle Plugin Version - 4.1.2
   Gradle version - 6.5
   Min SDK - 23 required by ArcGIS runtime
   ArcGIS runtime version - 100.10.0
   test runner version
   materialLibraryVersion
   appcompatLibraryVersion

- Update app versionName to 0.1.4